### PR TITLE
fix(workflows): support yarn foreach publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Changelog
         if: ${{ !cancelled() }}
-        run: yarn workspaces changed foreach -v --no-private --exclude . changelog generate
+        run: yarn workspaces changed foreach -v --no-private --exclude . exec "yarn changelog generate"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -86,22 +86,17 @@ jobs:
 
       - name: Release
         if: ${{ !cancelled() }}
-        run: yarn workspaces changed foreach -v --no-private --exclude . release create
+        run: yarn workspaces changed foreach -v --no-private --exclude . exec "yarn release create"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Force Yarn to use NPM Registry
-        if: ${{ !cancelled() }}
-        run: |
-          yarn config set npmScopes.atls.npmRegistryServer ${{ inputs.registryServer }}
-          yarn config set npmRegistryServer ${{ inputs.registryServer }}
-        shell: bash
-
       - name: Npm Publish
         if: ${{ !cancelled() }}
-        run: yarn workspaces changed foreach -v --no-private --exclude . npm publish --access public
+        run: yarn workspaces changed foreach -v --no-private --exclude . npm publish --tolerate-republish --access public
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.npmAuthToken }}
+          YARN_NPM_REGISTRY_SERVER: ${{ inputs.registryServer }}
+          YARN_NPM_PUBLISH_REGISTRY: ${{ inputs.registryServer }}
 
       - name: Compose commit message
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Таска
- Close atls/shared#107

## Как проверять
### До фикса
1. Контекст: reusable publish workflow после merge PR с изменёнными workspaces.
Действие: workflow запускает Changelog и Release через `atls/shared/.github/workflows/publish.yaml@master`.
Ожидаемый результат: шаги падают с `Invalid subcommand name for iteration - use the 'run' keyword if you wish to execute a script`; registry step может записать publish-настройки в `.yarnrc.yml` репозитория-потребителя.

### После фикса
1. Контекст: reusable publish workflow в `atls/shared`.
Действие: проверить команды publish job и распарсить workflow YAML.
Ожидаемый результат: Changelog и Release вызываются через `exec "yarn ..."`, NPM publish получает registry через env и использует `--tolerate-republish`, workflow больше не мутирует `.yarnrc.yml`.

## Пруфы
- YAML parse
```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yaml"); puts "yaml ok"'
yaml ok
```

- Diff hygiene
```text
git diff --check
```

- Yarn foreach dry-run
```text
yarn workspaces foreach -A --no-private --exclude . --dry-run exec "yarn changelog generate"
yarn workspaces foreach -A --no-private --exclude . --dry-run exec "yarn release create"
```
