### PR TITLE
fix(workflows): use publish foreach commands

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Changelog
         if: ${{ !cancelled() }}
-        run: yarn workspaces changed foreach -v --no-private --exclude . exec "yarn changelog generate"
+        run: yarn workspaces changed foreach -v --no-private --exclude . exec 'cd "$PROJECT_CWD" && yarn workspace "$npm_package_name" changelog generate'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Release
         if: ${{ !cancelled() }}
-        run: yarn workspaces changed foreach -v --no-private --exclude . exec "yarn release create"
+        run: yarn workspaces changed foreach -v --no-private --exclude . exec 'cd "$PROJECT_CWD" && yarn workspace "$npm_package_name" release create'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Changelog
         if: ${{ !cancelled() }}
-        run: yarn workspaces changed foreach -v --no-private --exclude . exec 'cd "$PROJECT_CWD" && yarn workspace "$npm_package_name" changelog generate'
+        run: yarn workspaces changed foreach -v --no-private --exclude . changelog generate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Release
         if: ${{ !cancelled() }}
-        run: yarn workspaces changed foreach -v --no-private --exclude . exec 'cd "$PROJECT_CWD" && yarn workspace "$npm_package_name" release create'
+        run: yarn workspaces changed foreach -v --no-private --exclude . release create
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Таска
- Close atls/shared#110

## Как проверять
### До фикса
1. Контекст: reusable publish workflow после merge PR с изменёнными publishable workspaces.
Действие: шаги Changelog и Release запускаются через `workspaces changed foreach ... exec "yarn ..."`.
Ожидаемый результат: До фикса: `exec` переводит выполнение в cwd workspace, changelog-плагин открывает root-relative пути и падает с ENOENT.

### После фикса
1. Контекст: reusable publish workflow после merge PR с изменёнными publishable workspaces.
Действие: шаги Changelog и Release запускаются штатными plugin-командами через `workspaces changed foreach`, как в publish-контракте atls/raijin.
Ожидаемый результат: После фикса: `workspaces changed foreach` делегирует выполнение из root cwd, `changelog generate` видит корректные root-relative paths, `release create` остаётся штатной release-командой.

## Пруфы
- Raijin contract
```text
atls/raijin:.github/actions/changelog/action.yml
run: yarn workspaces changed foreach -v --exclude . changelog generate

atls/raijin:.github/actions/release/action.yaml
run: yarn workspaces changed foreach -v --exclude . release create
```

- YAML parse
```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yaml"); puts "yaml ok"'
yaml ok
```

- Diff hygiene
```text
git diff --check
```

- Hyperion changelog command check
```text
node .yarn/releases/yarn-remote.mjs workspaces foreach -A --include ui-admin/button changelog generate --stdout
```

- Hyperion release command check
```text
node .yarn/releases/yarn-remote.mjs workspaces foreach -A --include ui-admin/button release create --help
```
