### PR TITLE
ci: support reusable app release options

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,6 +13,11 @@ on:
         default: '1.55.0'
         required: false
         type: string
+      checksCommand:
+        description: 'Command to run project checks. Default: yarn checks run'
+        default: 'yarn checks run'
+        required: false
+        type: string
 
 jobs:
   checks:
@@ -58,6 +63,6 @@ jobs:
           fi
 
       - name: Checks
-        run: yarn checks run
+        run: ${{ inputs.checksCommand }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pack-image.yaml
+++ b/.github/workflows/pack-image.yaml
@@ -44,6 +44,9 @@ on:
       project:
         required: false
         description: 'Project name for publishing to registry. For GitHub - repo name.'
+      runtimeEnv:
+        required: false
+        description: 'Optional dotenv-style KEY=value lines exported before image pack.'
 
 jobs:
   run:
@@ -89,6 +92,31 @@ jobs:
 
       - name: Yarn install
         run: yarn install --inline-builds
+
+      - name: Export runtime environment
+        env:
+          RUNTIME_ENV: ${{ secrets.runtimeEnv }}
+        run: |
+          while IFS= read -r line || [ -n "$line" ]; do
+            line="${line%$'\r'}"
+
+            if [ -z "$line" ] || [[ "$line" == \#* ]]; then
+              continue
+            fi
+
+            if [[ "$line" != *=* ]]; then
+              echo "Invalid runtime env line: expected KEY=value"
+              exit 1
+            fi
+
+            value="${line#*=}"
+
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
+
+            echo "$line" >> "$GITHUB_ENV"
+          done <<< "$RUNTIME_ENV"
 
       - name: Setup Pack
         uses: buildpacks/github-actions/setup-pack@v5.10.0


### PR DESCRIPTION
## Таска
- Close atls/planning#519

## Как проверять
### Основной сценарий
1. Контекст: reusable checks workflow в приватном app-проекте
Действие: передать `checksCommand` вместо значения по умолчанию
Ожидаемый результат: workflow выполняет переданную команду и не принуждает проект к `yarn checks run` с package release

### Дополнительный сценарий
1. Контекст: reusable `pack-image` workflow для app-проекта с runtime env
Действие: передать secret `runtimeEnv` с dotenv-строками `KEY=value`
Ожидаемый результат: workflow экспортирует переменные в `GITHUB_ENV` перед `yarn image pack` и не требует локальной копии pack workflow в caller-репозитории

## Пруфы
- `actionlint -ignore 'shellcheck reported issue' .github/workflows/checks.yaml .github/workflows/pack-image.yaml` прошёл
- `git diff --check -- .github/workflows/checks.yaml .github/workflows/pack-image.yaml` прошёл
