### PR TITLE
fix(workflows): pass foreach jobs explicitly

### DIFF
--- a/.github/workflows/pack-image.yaml
+++ b/.github/workflows/pack-image.yaml
@@ -131,7 +131,7 @@ jobs:
         run: |
           PROJECT_LOWER=$(echo "$PROJECT" | tr '[:upper:]' '[:lower:]')
 
-          yarn workspaces changed foreach -vpj 2 image pack --publish --tag-policy hash-timestamp --registry "$REGISTRY_URL/$PROJECT_LOWER/$IMAGE_NAME_PREFIX"
+          yarn workspaces changed foreach --verbose --parallel --jobs 2 image pack --publish --tag-policy hash-timestamp --registry "$REGISTRY_URL/$PROJECT_LOWER/$IMAGE_NAME_PREFIX"
 
       - name: Pack and publish included packages
         if: ${{ inputs.include }}


### PR DESCRIPTION
## Таска
- Close atls/planning#635

## Как проверять
### До фикса
1. Контекст: GitHub Actions workflow `.github/workflows/pack-image.yaml`, шаг `Pack and publish`
Действие: выполнить команду `yarn workspaces changed foreach -vpj 2 image pack --publish --tag-policy hash-timestamp --registry "$REGISTRY_URL/$PROJECT_LOWER/$IMAGE_NAME_PREFIX"` на актуальном repo-managed Yarn CLI
Ожидаемый результат: До фикса: команда падает на разборе `--jobs` с `Invalid value for --jobs`

### После фикса
1. Контекст: GitHub Actions workflow `.github/workflows/pack-image.yaml`, шаг `Pack and publish`
Действие: выполнить workflow-команду с явными флагами `--verbose --parallel --jobs 2`
Ожидаемый результат: После фикса: Yarn получает числовое значение `--jobs` и не падает на разборе флагов

## Пруфы
- `git diff --check`
```bash
passed
```
- `yarn workspaces foreach --help`
```bash
-j,--jobs #0         The maximum number of parallel tasks that the execution will be limited to; or `unlimited`
```
- `atls/hyperion` failed release run
```bash
Usage Error: Invalid value for --jobs:

- .#1: Expected "unlimited" (got "true")
- .#2: Expected a number (got "true")
```
